### PR TITLE
Call SDL_Quit on object destruction instead of exit()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 tags
 CMakeLists.txt.user
 /build*/
+/.cproject
+/.project

--- a/src/libraries/RdUserInterfaceLib/DeadScreen.hpp
+++ b/src/libraries/RdUserInterfaceLib/DeadScreen.hpp
@@ -6,7 +6,6 @@
 #include <SDL.h>
 #include <SDL_image.h>
 #include <SDL_ttf.h>
-#include <cstdlib> // For some useful functions such as atexit :)
 #include <string>
 #include <yarp/os/ResourceFinder.h>
 

--- a/src/libraries/RdUserInterfaceLib/GameScreen.hpp
+++ b/src/libraries/RdUserInterfaceLib/GameScreen.hpp
@@ -6,7 +6,6 @@
 #include <SDL.h>
 #include <SDL_ttf.h>
 #include <X11/Xlib.h>
-#include <cstdlib> // For some useful functions such as atexit :)
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/libraries/RdUserInterfaceLib/SDLScreenManager.cpp
+++ b/src/libraries/RdUserInterfaceLib/SDLScreenManager.cpp
@@ -139,7 +139,6 @@ bool rd::SDLScreenManager::initSDL()
         RD_ERROR("SDL could not initialize!\n SDL Error: %s\n", SDL_GetError());
         return false;
     }
-    atexit(SDL_Quit); // Clean it up nicely :)
 
     //-- Init ttf
     if (TTF_Init() == -1)
@@ -159,7 +158,8 @@ bool rd::SDLScreenManager::initSDL()
 
 bool rd::SDLScreenManager::cleanupSDL()
 {
-    RD_WARNING("SDL cleanup not implemented!\n");
+    RD_INFO("Freeing resources...\n");
+    SDL_Quit();
     return true;
 }
 

--- a/src/libraries/RdUtilsLib/SDLUtils.cpp
+++ b/src/libraries/RdUtilsLib/SDLUtils.cpp
@@ -30,7 +30,6 @@ bool rd::initSDL()
         RD_ERROR("SDL could not initialize!\n SDL Error: %s\n", SDL_GetError());
         return false;
     }
-    atexit(SDL_Quit); // Clean it up nicely :)
 
     //-- Init ttf
     if (TTF_Init() == -1)
@@ -50,6 +49,7 @@ bool rd::initSDL()
 
 bool rd::cleanupSDL()
 {
-    RD_WARNING("SDL cleanup not implemented!\n");
+    RD_INFO("Freeing resources...\n");
+    SDL_Quit();
     return true;
 }

--- a/src/libraries/RdUtilsLib/SDLUtils.hpp
+++ b/src/libraries/RdUtilsLib/SDLUtils.hpp
@@ -7,7 +7,6 @@
 #include <SDL.h>
 #include <SDL_image.h>
 #include <SDL_ttf.h>
-#include <cstdlib> // For some useful functions such as atexit :)
 
 namespace rd {
 

--- a/test/testRdInputManager.cpp
+++ b/test/testRdInputManager.cpp
@@ -17,6 +17,8 @@
 #include <SDL.h>
 #include <SDL_ttf.h>
 
+#include <cstdlib> // atexit()
+
 using namespace rd;
 
 bool finished = false;
@@ -156,7 +158,7 @@ int main(void)
     fprintf(stderr, "Unable to initialize SDL: %s\n", SDL_GetError());
     return false;
     }
-    atexit(SDL_Quit); // Clean it up nicely :)
+    atexit(SDL_Quit); // Clean it up nicely :) FIXME: #70
 
     //-- Init screen
     SDL_Window * window = SDL_CreateWindow("Robot Devastation",
@@ -206,5 +208,6 @@ int main(void)
     }
 
     RdInputManager::destroyInputManager();
-    SDL_Quit();
+
+    return 0;
 }

--- a/test/testSDLTextDisplay.cpp
+++ b/test/testSDLTextDisplay.cpp
@@ -1,6 +1,6 @@
 #include <SDL.h>
 #include <SDL_ttf.h>
-#include <cstdlib> // For some useful functions such as atexit :)
+#include <cstdlib> // atexit()
 #include <iostream>
 #include <yarp/os/ResourceFinder.h>
 
@@ -23,7 +23,7 @@ int main(void)
     fprintf(stderr, "Unable to initialize SDL: %s\n", SDL_GetError());
     return false;
     }
-    atexit(SDL_Quit); // Clean it up nicely :)
+    atexit(SDL_Quit); // Clean it up nicely :) FIXME: #70
 
     //-- Init ttf
     if (TTF_Init() == -1)
@@ -102,4 +102,5 @@ int main(void)
     SDL_FreeSurface(screen);
     SDL_FreeSurface(text_surface);
 
+    return 0;
 }


### PR DESCRIPTION
Remaining atexit() occurrences were kept until a better solution is found. Also add missing return values to tests and remove superfluous includes of &lt;cstdlib&gt;. Fixes #70.