### PR TITLE
Create Windows port

### DIFF
--- a/src/libraries/GameStatesLib/CMakeLists.txt
+++ b/src/libraries/GameStatesLib/CMakeLists.txt
@@ -4,11 +4,14 @@ cmake_minimum_required(VERSION 2.6)
 
 set(KEYWORD "GameStatesLib")
 
+find_package(YARP REQUIRED)
+
+include_directories(${YARP_INCLUDE_DIRS})
 include_directories(${RD_INCLUDE_DIRS})
 
 add_library(${KEYWORD} InitState.cpp GameState.cpp DeadState.cpp)
 
-target_link_libraries(${KEYWORD} ${RD_LIBRARIES} RdUserInterfaceLib StateMachineLib RdUtilsLib)
+target_link_libraries(${KEYWORD} ${RD_LIBRARIES} ${YARP_LIBRARIES} RdUserInterfaceLib StateMachineLib RdUtilsLib)
 install(TARGETS ${KEYWORD} DESTINATION lib)
 
 # Exporting dependencies for RDConfig.cmake quite manually for now...

--- a/src/libraries/GameStatesLib/GameState.cpp
+++ b/src/libraries/GameStatesLib/GameState.cpp
@@ -302,4 +302,5 @@ bool rd::GameState::onImageArrived(rd::RdImageManager *manager)
 {
     //-- Don't know if this is safe enough or some mutex is required
     screenManager->update(GameScreen::PARAM_CAMERA_FRAME, manager->getImage());
+    return true;
 }

--- a/src/libraries/RdImageLib/RdMockupImageEventListener.cpp
+++ b/src/libraries/RdImageLib/RdMockupImageEventListener.cpp
@@ -10,6 +10,7 @@ bool rd::RdMockupImageEventListener::onImageArrived(rd::RdImageManager *manager)
 {
     stored_image = manager->getImage();
     images_arrived++;
+    return true;
 }
 
 int rd::RdMockupImageEventListener::getImagesArrived() { return images_arrived; }

--- a/src/libraries/RdImageLib/RdProcessorImageEventListener.cpp
+++ b/src/libraries/RdImageLib/RdProcessorImageEventListener.cpp
@@ -98,7 +98,7 @@ bool rd::RdProcessorImageEventListener::onImageArrived( RdImageManager * manager
     }
 
     mentalMap->updateTargets(targets);
-
+    return true;
 }
 
 int rd::RdProcessorImageEventListener::getImagesArrived()

--- a/src/libraries/RdInputLib/CMakeLists.txt
+++ b/src/libraries/RdInputLib/CMakeLists.txt
@@ -6,7 +6,6 @@ set(KEYWORD "RdInputLib")
 
 find_package(YARP REQUIRED)
 find_package(SDL2 REQUIRED)
-find_package(X11 REQUIRED)
 
 include_directories(${YARP_INCLUDE_DIRS})
 include_directories(${SDL2_INCLUDE_DIR})
@@ -16,7 +15,7 @@ include_directories(${RD_INCLUDE_DIRS})
 add_library(${KEYWORD} RdInputManager.cpp RdSDLInputManager.cpp MockupInputManager.cpp RdKey.cpp RdWindowEvent.cpp
 RdSDLEventFactory.cpp RdInputEventListener.hpp MockupInputEventListener.cpp)
 
-target_link_libraries(${KEYWORD} ${SDL2_LIBRARY} ${YARP_LIBRARIES} ${X11_LIBRARIES})
+target_link_libraries(${KEYWORD} ${SDL2_LIBRARY} ${YARP_LIBRARIES})
 install(TARGETS ${KEYWORD} DESTINATION lib)
 
 # Exporting dependencies for RDConfig.cmake quite manually for now...

--- a/src/libraries/RdInputLib/RdSDLInputManager.cpp
+++ b/src/libraries/RdInputLib/RdSDLInputManager.cpp
@@ -64,9 +64,6 @@ rd::RdSDLInputManager::RdSDLInputManager()
     //-- Init SDL
     ////////if (SDL_WasInit( SDL_INIT_EVENTTHREAD) == 0)
     ////////////7    SDL_Init(SDL_INIT_EVENTTHREAD);
-
-    //-- Init X11 threads
-    XInitThreads();
 }
 
 bool rd::RdSDLInputManager::inputCallback(SDL_Event *event)

--- a/src/libraries/RdInputLib/RdSDLInputManager.hpp
+++ b/src/libraries/RdInputLib/RdSDLInputManager.hpp
@@ -4,7 +4,6 @@
 #define __RD_SDL_INPUT_MANAGER_HPP__
 
 #include <SDL.h>
-#include <X11/Xlib.h>
 #include <yarp/os/RateThread.h>
 
 #include "RdInputManager.hpp"

--- a/src/libraries/RdNetworkLib/MockupNetworkEventListener.cpp
+++ b/src/libraries/RdNetworkLib/MockupNetworkEventListener.cpp
@@ -10,6 +10,7 @@ bool rd::MockupNetworkEventListener::onDataArrived(std::vector<rd::RdPlayer> pla
 {
     stored_players = players;
     data_arrived++;
+    return true;
 }
 
 int rd::MockupNetworkEventListener::getDataArrived()

--- a/src/libraries/RdNetworkLib/MockupNetworkManager.cpp
+++ b/src/libraries/RdNetworkLib/MockupNetworkManager.cpp
@@ -32,6 +32,7 @@ bool rd::MockupNetworkManager::start()
 bool rd::MockupNetworkManager::stop()
 {
     stopped = true;
+    return true;
 }
 
 bool rd::MockupNetworkManager::configure(std::string parameter, RdPlayer value)
@@ -177,6 +178,7 @@ bool rd::MockupNetworkManager::sendPlayerData()
     //-- Notify listeners
     for(int i = 0; i < listeners.size(); i++)
         listeners[i]->onDataArrived(this->getPlayerData());
+    return true;
 }
 
 bool rd::MockupNetworkManager::setLoggedIn(bool logged_in)

--- a/src/libraries/RdNetworkLib/RdYarpNetworkManager.cpp
+++ b/src/libraries/RdNetworkLib/RdYarpNetworkManager.cpp
@@ -81,7 +81,7 @@ bool rd::RdYarpNetworkManager::start()
         RD_ERROR("Could not connect robotDevastation RpcClient to rdServer RpcServer (launch 'rdServer' if not already launched).\n");
         return false;
     }
-    RD_SUCCESS("Connected robotDevastation RpcClient to rdServer RpcServer!\n")
+    RD_SUCCESS("Connected robotDevastation RpcClient to rdServer RpcServer!\n");
 
     //-- Connect from rdServer info to robotDevastation callbackPort
     if ( !yarp::os::Network::connect( "/rdServer/info:o", callback_str.str() ))
@@ -89,7 +89,7 @@ bool rd::RdYarpNetworkManager::start()
         RD_ERROR("Could not connect from rdServer info to robotDevastation callbackPort (launch 'rdServer' if not already launched).\n");
         return false;
     }
-    RD_SUCCESS("Connected from rdServer info to robotDevastation callbackPort!\n")
+    RD_SUCCESS("Connected from rdServer info to robotDevastation callbackPort!\n");
 
     callbackPort.useCallback(*this);
 

--- a/src/libraries/RdUserInterfaceLib/DeadScreen.cpp
+++ b/src/libraries/RdUserInterfaceLib/DeadScreen.cpp
@@ -27,7 +27,7 @@ bool rd::DeadScreen::init()
     skull_image = IMG_Load(rf.findFileByName(SKULL_PATH).c_str());
     if (skull_image == NULL)
     {
-        RD_ERROR("Unable to load skull image (resource: %s)!\n SDL_image Error: %s\n", SKULL_PATH.c_str(), IMG_GetError())
+        RD_ERROR("Unable to load skull image (resource: %s)!\n SDL_image Error: %s\n", SKULL_PATH.c_str(), IMG_GetError());
         return false;
     }
 

--- a/src/libraries/RdUserInterfaceLib/GameScreen.hpp
+++ b/src/libraries/RdUserInterfaceLib/GameScreen.hpp
@@ -5,7 +5,6 @@
 
 #include <SDL.h>
 #include <SDL_ttf.h>
-#include <X11/Xlib.h>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/libraries/RdUserInterfaceLib/InitScreen.cpp
+++ b/src/libraries/RdUserInterfaceLib/InitScreen.cpp
@@ -19,13 +19,13 @@ bool rd::InitScreen::init()
     yarp::os::ConstString splashPath = rf.findFileByName(SPLASH_PATH);
     if (splashPath == "")
     {
-        RD_ERROR("Unable to find splash screen (resource: %s)!\n", splashPath.c_str())
+        RD_ERROR("Unable to find splash screen (resource: %s)!\n", splashPath.c_str());
         return false;
     }
     image = IMG_Load(splashPath.c_str());
     if (image == NULL)
     {
-        RD_ERROR("Unable to load splash screen (resource: %s)!\n SDL_image Error: %s\n", splashPath.c_str(), IMG_GetError())
+        RD_ERROR("Unable to load splash screen (resource: %s)!\n SDL_image Error: %s\n", splashPath.c_str(), IMG_GetError());
         return false;
     }
 

--- a/src/libraries/RdUserInterfaceLib/MockupScreen.cpp
+++ b/src/libraries/RdUserInterfaceLib/MockupScreen.cpp
@@ -27,7 +27,7 @@ bool rd::MockupScreen::init()
     background = IMG_Load(rf.findFileByName(IMAGE_PATH).c_str());
     if (background == NULL)
     {
-        RD_ERROR("Unable to load background image (resource: %s)!\n SDL_image Error: %s\n", IMAGE_PATH.c_str(), IMG_GetError())
+        RD_ERROR("Unable to load background image (resource: %s)!\n SDL_image Error: %s\n", IMAGE_PATH.c_str(), IMG_GetError());
         return false;
     }
 

--- a/src/libraries/RdUtilsLib/CMakeLists.txt
+++ b/src/libraries/RdUtilsLib/CMakeLists.txt
@@ -7,13 +7,15 @@ set(KEYWORD "RdUtilsLib")
 find_package(YARP REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(SDL2_image REQUIRED)
+find_package(SDL2_mixer REQUIRED)
+find_package(SDL2_ttf REQUIRED)
 
 include_directories(${YARP_INCLUDE_DIRS})
-include_directories(${SDL2_INCLUDE_DIR} ${SDL2_IMAGE_INCLUDE_DIR})
+include_directories(${SDL2_INCLUDE_DIR} ${SDL2_IMAGE_INCLUDE_DIR} ${SDL2_MIXER_INCLUDE_DIRS} ${SDL2_TTF_INCLUDE_DIR})
 include_directories(${RD_INCLUDE_DIRS})
 
 add_library(${KEYWORD} Hub.cpp RdIniReader.hpp RdMacros.hpp RdUtils.hpp RdVector2dBase.hpp RdVocabs.hpp SDLUtils.cpp)
-target_link_libraries(${KEYWORD} ${SDL2_LIBRARY} ${SDL2_IMAGE_LIBRARIES} ${YARP_LIBRARIES} ${RD_LIBRARIES})
+target_link_libraries(${KEYWORD} ${SDL2_LIBRARY} ${SDL2_IMAGE_LIBRARIES} ${SDL2_MIXER_LIBRARIES} ${SDL2_TTF_LIBRARIES} ${YARP_LIBRARIES} ${RD_LIBRARIES})
 install(TARGETS ${KEYWORD} DESTINATION lib)
 
 # Exporting dependencies for RDConfig.cmake quite manually for now...

--- a/src/libraries/RdUtilsLib/Hub.cpp
+++ b/src/libraries/RdUtilsLib/Hub.cpp
@@ -23,10 +23,10 @@ rd::ManagerHub::ManagerHub(rd::RdNetworkManager *networkManager, rd::RdImageMana
     this->screenManager = screenManager;
 }
 
-bool rd::ManagerHub::setNetworkManager(rd::RdNetworkManager *networkManager) { this->networkManager = networkManager;}
-bool rd::ManagerHub::setImageManager(rd::RdImageManager *imageManager) { this->imageManager = imageManager;}
-bool rd::ManagerHub::setInputManager(rd::RdInputManager *inputManager) { this->inputManager = inputManager;}
-bool rd::ManagerHub::setMentalMap(rd::RdMentalMap *mentalMap) { this->mentalMap = mentalMap;}
-bool rd::ManagerHub::setRobotManager(rd::RdRobotManager *robotManager) { this->robotManager = robotManager;}
-bool rd::ManagerHub::setAudioManager(rd::AudioManager *audioManager) { this->audioManager = audioManager;}
-bool rd::ManagerHub::setScreenManager(rd::ScreenManager *screenManager) {this->screenManager = screenManager;}
+bool rd::ManagerHub::setNetworkManager(rd::RdNetworkManager *networkManager) { this->networkManager = networkManager; return true; }
+bool rd::ManagerHub::setImageManager(rd::RdImageManager *imageManager) { this->imageManager = imageManager; return true; }
+bool rd::ManagerHub::setInputManager(rd::RdInputManager *inputManager) { this->inputManager = inputManager; return true; }
+bool rd::ManagerHub::setMentalMap(rd::RdMentalMap *mentalMap) { this->mentalMap = mentalMap; return true; }
+bool rd::ManagerHub::setRobotManager(rd::RdRobotManager *robotManager) { this->robotManager = robotManager; return true; }
+bool rd::ManagerHub::setAudioManager(rd::AudioManager *audioManager) { this->audioManager = audioManager; return true; }
+bool rd::ManagerHub::setScreenManager(rd::ScreenManager *screenManager) { this->screenManager = screenManager; return true; }

--- a/src/libraries/RdUtilsLib/RdMacros.hpp
+++ b/src/libraries/RdUtilsLib/RdMacros.hpp
@@ -10,9 +10,32 @@
 namespace rdlib{
 
 //-- Thanks http://stackoverflow.com/questions/8487986/file-macro-shows-full-path
+#ifdef WIN32
+#define __REL_FILE__ (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
+#else
 #define __REL_FILE__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-// For Windows use '\\' instead of '/'.
+#endif
 
+#ifdef WIN32
+// Could be implemented for Win10: http://stackoverflow.com/a/38617204
+#define RESET   ""
+#define BLACK   ""      /* Black */
+#define RED     ""      /* Red */
+#define GREEN   ""      /* Green */
+#define YELLOW  ""      /* Yellow */
+#define BLUE    ""      /* Blue */
+#define MAGENTA ""      /* Magenta */
+#define CYAN    ""      /* Cyan */
+#define WHITE   ""      /* White */
+#define BOLDBLACK   ""      /* Bold Black */
+#define BOLDRED     ""      /* Bold Red */
+#define BOLDGREEN   ""      /* Bold Green */
+#define BOLDYELLOW  ""      /* Bold Yellow */
+#define BOLDBLUE    ""      /* Bold Blue */
+#define BOLDMAGENTA ""      /* Bold Magenta */
+#define BOLDCYAN    ""      /* Bold Cyan */
+#define BOLDWHITE   ""      /* Bold White */
+#else
 // http://stackoverflow.com/questions/1961209/making-some-text-in-printf-appear-in-green-and-red
 #define RESET   "\033[0m"
 #define BLACK   "\033[30m"      /* Black */
@@ -31,14 +54,8 @@ namespace rdlib{
 #define BOLDMAGENTA "\033[1m\033[35m"      /* Bold Magenta */
 #define BOLDCYAN    "\033[1m\033[36m"      /* Bold Cyan */
 #define BOLDWHITE   "\033[1m\033[37m"      /* Bold White */
+#endif
 
-#ifdef WIN32
-#define RD_ERROR printf
-#define RD_WARNING printf
-#define RD_SUCCESS printf
-#define RD_INFO printf
-#define RD_DEBUG printf
-#else //linux
 // http://en.wikipedia.org/wiki/Variadic_macro
 // http://stackoverflow.com/questions/15549893/modify-printfs-via-macro-to-include-file-and-line-number-information
 #define RD_ERROR(...) { fprintf(stderr,RED); do{fprintf(stderr, "[error] %s:%d %s(): ", __REL_FILE__, __LINE__, __func__); \
@@ -55,8 +72,6 @@ namespace rdlib{
 
 #define RD_DEBUG(...) { fprintf(stderr,BLUE); do{printf("[debug] %s:%d %s(): ", __REL_FILE__, __LINE__, __func__); \
                            printf(__VA_ARGS__);} while(0); fprintf(stderr,RESET); }
-
-#endif
 
 } //rdlib
 

--- a/src/libraries/StateMachineLib/CMakeLists.txt
+++ b/src/libraries/StateMachineLib/CMakeLists.txt
@@ -4,11 +4,14 @@ cmake_minimum_required(VERSION 2.6)
 
 set(KEYWORD "StateMachineLib")
 
+find_package(YARP REQUIRED)
+
+include_directories(${YARP_INCLUDE_DIRS})
 include_directories(${RD_INCLUDE_DIRS})
 
 add_library(${KEYWORD} StateMachine.cpp StateMachineBuilder.cpp State.cpp MockupState.cpp StateDirector.cpp YarpStateDirector.cpp)
 
-target_link_libraries(${KEYWORD})
+target_link_libraries(${KEYWORD} ${YARP_LIBRARIES})
 install(TARGETS ${KEYWORD} DESTINATION lib)
 
 # Exporting dependencies for RDConfig.cmake quite manually for now...

--- a/src/libraries/StateMachineLib/YarpStateDirector.cpp
+++ b/src/libraries/StateMachineLib/YarpStateDirector.cpp
@@ -35,7 +35,6 @@ bool rd::YarpStateDirector::Stop()
     active = false;
 
     yarp::os::RateThread::askToStop();
-    yarp::os::RateThread::stop();
 
     if (state != NULL)
         state->cleanup();

--- a/src/programs/rdServer/CMakeLists.txt
+++ b/src/programs/rdServer/CMakeLists.txt
@@ -25,6 +25,11 @@ endforeach(header_file ${folder_header})
 include_directories(${YARP_INCLUDE_DIRS})
 include_directories(${RD_INCLUDE_DIRS})
 
+# Define symbols
+if (WIN32)
+  ADD_DEFINITIONS(-DSDL_MAIN_HANDLED)
+endif (WIN32)
+
 # Set up our main executable.
 if (folder_source)
   add_executable(${KEYWORD} ${folder_source} ${folder_header})

--- a/src/programs/rdServer/CMakeLists.txt
+++ b/src/programs/rdServer/CMakeLists.txt
@@ -27,7 +27,7 @@ include_directories(${RD_INCLUDE_DIRS})
 
 # Define symbols
 if (WIN32)
-  ADD_DEFINITIONS(-DSDL_MAIN_HANDLED)
+  add_definitions(-DSDL_MAIN_HANDLED)
 endif (WIN32)
 
 # Set up our main executable.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,21 +1,30 @@
 # Testing things #########################################################################################
+set(gtest_force_shared_crt ON) # needed for Windows
 add_subdirectory(gtest-1.7.0)
 enable_testing()
-include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR} ${RD_INCLUDE_DIRS})
+
+find_package(YARP REQUIRED)
+find_package(SDL2 REQUIRED)
+find_package(SDL2_image REQUIRED)
+find_package(SDL2_ttf REQUIRED)
+
+include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR} ${RD_INCLUDE_DIRS} ${YARP_INCLUDE_DIRS})
+include_directories(${SDL2_INCLUDE_DIRS} ${SDL2_IMAGE_INCLUDE_DIRS} ${SDL2_TTF_INCLUDE_DIRS})
 link_directories(${RD_LINK_DIRS})
+add_definitions(-DSDL_MAIN_HANDLED) # needed for Windows
 
 # UI related
 add_executable(testSDLTextDisplay testSDLTextDisplay.cpp)
-target_link_libraries(testSDLTextDisplay ${RD_LIBRARIES} SDL2 SDL2_image SDL2_ttf)
+target_link_libraries(testSDLTextDisplay ${RD_LIBRARIES})
 
 add_executable(testInitScreen testInitScreen.cpp)
-target_link_libraries(testInitScreen ${RD_LIBRARIES} SDL2 SDL2_image SDL2_ttf gtest gtest_main)
+target_link_libraries(testInitScreen ${RD_LIBRARIES} gtest gtest_main)
 
 add_executable(testGameScreen testGameScreen.cpp)
-target_link_libraries(testGameScreen ${RD_LIBRARIES} SDL2 SDL2_image SDL2_ttf gtest gtest_main)
+target_link_libraries(testGameScreen ${RD_LIBRARIES} gtest gtest_main)
 
 add_executable(testDeadScreen testDeadScreen.cpp)
-target_link_libraries(testDeadScreen ${RD_LIBRARIES} SDL2 SDL2_image SDL2_ttf gtest gtest_main)
+target_link_libraries(testDeadScreen ${RD_LIBRARIES} gtest gtest_main)
 
 add_executable(testMockupScreen testMockupScreen.cpp)
 target_link_libraries(testMockupScreen ${RD_LIBRARIES})

--- a/test/testRdInputManager.cpp
+++ b/test/testRdInputManager.cpp
@@ -112,6 +112,7 @@ class RdTestEventListener : public RdInputEventListener
                     RD_SUCCESS("Exit!\n");
                 }
             }
+            return true;
         }
 
         virtual bool onKeyUp(const RdKey & k)
@@ -145,6 +146,7 @@ class RdTestEventListener : public RdInputEventListener
                 RD_SUCCESS( "Key \"%c\" was released!\n", k.getChar() );
 
             }
+            return true;
         }
 
         virtual bool onWindowEvent(const RdWindowEvent & event)
@@ -163,6 +165,7 @@ class RdTestEventListener : public RdInputEventListener
                     RD_SUCCESS("Exit!\n");
                 }
             }
+            return true;
         }
 
     private:
@@ -173,8 +176,8 @@ int main(void)
 {
     // Load SDL
     if (SDL_Init(SDL_INIT_VIDEO) != 0) {
-    fprintf(stderr, "Unable to initialize SDL: %s\n", SDL_GetError());
-    return false;
+        fprintf(stderr, "Unable to initialize SDL: %s\n", SDL_GetError());
+        return false;
     }
     atexit(SDL_Quit); // Clean it up nicely :)
 

--- a/test/testRdYarpImageManager.cpp
+++ b/test/testRdYarpImageManager.cpp
@@ -7,6 +7,13 @@
 #include "RdYarpImageManager.hpp"
 #include "RdMockupImageEventListener.hpp"
 
+#ifdef WIN32
+#include <Windows.h>
+#define MY_SLEEP(seconds) Sleep(seconds * 1000)
+#else
+#define MY_SLEEP(seconds) sleep(seconds)
+#endif
+
 using namespace rd;
 
 
@@ -105,14 +112,14 @@ TEST_F( RdYarpImageManagerTest, RdYarpImageManagerWorks)
     ASSERT_TRUE(imageManager->start());
 
     //-- Wait for a image to arrive
-    usleep(1e6);
+    MY_SLEEP(1);
 
     //-- Check that a image didn't arrive
     EXPECT_EQ(0, listener.getImagesArrived());
 
     //-- Enable and wait for a image to arrive
     ASSERT_TRUE(imageManager->setEnabled(true));
-    usleep(1e6);
+    MY_SLEEP(1);
 
     //-- Check that a image arrived
     EXPECT_LE( 1, listener.getImagesArrived());
@@ -120,7 +127,7 @@ TEST_F( RdYarpImageManagerTest, RdYarpImageManagerWorks)
     //-- Check that disabling again works
     ASSERT_TRUE(imageManager->setEnabled(false));
     listener.resetImagesArrived();
-    usleep(1e6);
+    MY_SLEEP(1);
     EXPECT_EQ(0, listener.getImagesArrived());
 
     //-- Dettach the listener

--- a/test/testSDLAudioManager.cpp
+++ b/test/testSDLAudioManager.cpp
@@ -4,6 +4,13 @@
 
 #include "SDLAudioManager.hpp"
 
+#ifdef WIN32
+#include <Windows.h>
+#define MY_SLEEP(seconds) Sleep(seconds * 1000)
+#else
+#define MY_SLEEP(seconds) sleep(seconds)
+#endif
+
 using namespace rd;
 
 class MockupAudioManagerTest : public testing::Test
@@ -72,7 +79,7 @@ TEST_F( MockupAudioManagerTest, AudioManagerPlaysOneSound )
     ASSERT_TRUE(audioManager->load(sound_bso_realpath, "bso", SDLAudioManager::MUSIC));
 
     EXPECT_TRUE(audioManager->play("bso", true));
-    sleep(2);
+    MY_SLEEP(2);
     EXPECT_TRUE(audioManager->stopMusic());
 }
 
@@ -84,9 +91,9 @@ TEST_F( MockupAudioManagerTest, AudioManagerPlaysFx )
     ASSERT_TRUE(audioManager->load(sound_explosion_realpath, "explosion", SDLAudioManager::FX));
 
     EXPECT_TRUE(audioManager->play("shoot", false));
-    sleep(1);
+    MY_SLEEP(1);
     EXPECT_TRUE(audioManager->play("explosion", false));
-    sleep(2);
+    MY_SLEEP(2);
 }
 
 TEST_F( MockupAudioManagerTest, AudioManagerPlaysAllSounds )
@@ -99,8 +106,8 @@ TEST_F( MockupAudioManagerTest, AudioManagerPlaysAllSounds )
 
     EXPECT_TRUE(audioManager->play("bso", true));
     EXPECT_TRUE(audioManager->play("shoot", true));
-    sleep(1);
+    MY_SLEEP(1);
     EXPECT_TRUE(audioManager->play("explosion", false));
-    sleep(4);
+    MY_SLEEP(4);
     EXPECT_TRUE(audioManager->stopMusic());
 }


### PR DESCRIPTION
Tested on Windows 10 64 bits (compiled for 32 bits), Visual Studio 2015. Closes #12.

Remarks:
* robotology/yarp#1085
* the `opencv_grabber` plugin does not seem to work on this configuration (no problem on Linux); it's still using the old OpenCV 1 interface, we found out that the `cv::Mat` way of doing this solves the problem